### PR TITLE
Reco param fix

### DIFF
--- a/pisa/reco/RecoServiceParam.py
+++ b/pisa/reco/RecoServiceParam.py
@@ -82,7 +82,6 @@ class RecoServiceParam(RecoServiceBase):
         parametrization = {}
         for flavour in param_str:
           parametrization[flavour] = {}
-          #for int_type in ['cc', 'nc']:
           for int_type in param_str[flavour]:    #['cc', 'nc']
             logging.debug('Parsing function strings for %s %s'
                           %(flavour, int_type))

--- a/pisa/reco/RecoServiceParam.py
+++ b/pisa/reco/RecoServiceParam.py
@@ -10,8 +10,6 @@
 # date:   October 9, 2014
 #
 
-import sys
-import os
 import logging
 import itertools
 from copy import deepcopy as copy

--- a/pisa/reco/RecoServiceParam.py
+++ b/pisa/reco/RecoServiceParam.py
@@ -26,7 +26,7 @@ from pisa.utils.utils import get_binning, is_logarithmic, get_bin_centers, get_b
 
 
 
-def double_gauss(bin_centers, bin_edges, loc1=0, width1=1.e-6, loc2=0, width2=1.e-6, fraction=0.):
+def double_gauss(bin_edges, loc1=0, width1=1.e-6, loc2=0, width2=1.e-6, fraction=0.):
     """Superposition of two gaussians"""
 
     n1 = norm(loc=loc1, scale=width1)
@@ -175,8 +175,7 @@ class RecoServiceParam(RecoServiceBase):
             # loop over every bin in true (energy, coszen)
             for (i, j) in itertools.product(range(n_e), range(n_cz)):
 
-                e_kern_cdf = double_gauss(evals,
-                                          self.ebins,
+                e_kern_cdf = double_gauss(self.ebins,
                                           loc1=e_pars['loc1'][i,j]+evals[i],
                                           width1=e_pars['width1'][i,j],
                                           loc2=e_pars['loc2'][i,j]+evals[i],
@@ -185,8 +184,7 @@ class RecoServiceParam(RecoServiceBase):
 		e_kern_int = np.sum(e_kern_cdf)
                 offset = n_cz if flipback else 0
 
-                cz_kern_cdf = double_gauss(czvals,
-                                           czbins,
+                cz_kern_cdf = double_gauss(czbins,
                                            loc1=cz_pars['loc1'][i,j]+czvals[j+offset],
                                            width1=cz_pars['width1'][i,j],
                                            loc2=cz_pars['loc2'][i,j]+czvals[j+offset],

--- a/pisa/reco/RecoServiceParam.py
+++ b/pisa/reco/RecoServiceParam.py
@@ -182,6 +182,7 @@ class RecoServiceParam(RecoServiceBase):
                                           width2=e_pars['width2'][i,j],
                                           fraction=e_pars['fraction'][i,j])
 		e_kern_int = np.sum(e_kern_cdf)
+
                 offset = n_cz if flipback else 0
 
                 cz_kern_cdf = double_gauss(czbins,
@@ -197,8 +198,6 @@ class RecoServiceParam(RecoServiceBase):
                     cz_kern_cdf = cz_kern_cdf[:len(czbins)/2][::-1] + cz_kern_cdf[len(czbins)/2:]
 
                 kernel[i,j] = np.outer(e_kern_cdf, cz_kern_cdf)
-                kernel[i,j]*=e_kern_int*cz_kern_int/np.sum(kernel[i,j])
-                
 
             kernel_dict[flavour][int_type] = copy(kernel)
 


### PR DESCRIPTION
Replaced pdf with cdf to give correct normalization of reconstruction kernels when Gaussian widths are less than bin widths. No separate normalization step needed.