### PR TITLE
Fix TemplateMaker for non-GPU use

### DIFF
--- a/pisa/analysis/TemplateMaker.py
+++ b/pisa/analysis/TemplateMaker.py
@@ -27,12 +27,12 @@ from pisa.flux.Flux import get_flux_maps
 
 from pisa.oscillations.Prob3OscillationService import Prob3OscillationService
 from pisa.oscillations.NucraftOscillationService import NucraftOscillationService
-#try:
-#    print "Trying to import Prob3GPUOscillationService..."
-from pisa.oscillations.Prob3GPUOscillationService import Prob3GPUOscillationService
-#except:
-#    pass
-#    print "CAN NOT import Prob3GPUOscillationService..."
+try:
+    print "Trying to import Prob3GPUOscillationService..."
+    from pisa.oscillations.Prob3GPUOscillationService import Prob3GPUOscillationService
+except:
+    pass
+    print "CAN NOT import Prob3GPUOscillationService..."
 from pisa.oscillations.Oscillation import get_osc_flux
 
 from pisa.aeff.AeffServiceMC import AeffServiceMC

--- a/pisa/resources/settings/template_settings/V36_LoI_7syst_e39_cz20_GPU.json
+++ b/pisa/resources/settings/template_settings/V36_LoI_7syst_e39_cz20_GPU.json
@@ -171,7 +171,7 @@
       "value": null
     },
     "atm_delta_index": {
-      "fixed": false,
+      "fixed": true,
       "prior": {
         "fiducial": 0.0,
         "kind": "gaussian",
@@ -231,7 +231,9 @@
     "deltam31_ih": {
       "fixed": false,
       "prior": {
-        "kind": "uniform"
+        "fiducial": -0.00237,
+        "kind": "gaussian",
+        "sigma": 5e-05
       },
       "range": [
         -0.0025,
@@ -243,7 +245,9 @@
     "deltam31_nh": {
       "fixed": false,
       "prior": {
-        "kind": "uniform"
+        "fiducial": 0.00246,
+        "kind": "gaussian",
+        "sigma": 5e-05
       },
       "range": [
         0.0023,
@@ -326,7 +330,7 @@
     },
     "osc_code": {
       "fixed": true,
-      "value": "prob3"
+      "value": "gpu"
     },
     "pid_kernelfile": {
       "fixed": true,


### PR DESCRIPTION
* Re-add try-except for `Prob3GPUOscillationService` in `TemplateMaker`
* use non-GPU prob3 in default settings file
* add GPU-version of default settings file